### PR TITLE
fix(vercel): ensure Prisma Client is generated during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
+    "postinstall": "prisma generate",
     "db:seed": "prisma db seed",
     "db:reset": "prisma migrate reset --force",
     "db:push": "prisma db push",


### PR DESCRIPTION
- Update build script to run 'prisma generate' before 'next build' to fix PrismaClientInitializationError on Vercel
- Add postinstall script to always generate Prisma Client after install
- This ensures Prisma Client is always up-to-date in Vercel's cached environment